### PR TITLE
 Update check_patches_clean_apply.py to work with rattler-build  and add pixi run check-patches in CI

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -131,29 +131,34 @@ jobs:
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-64'
       run: |
+        env -i $HOME/.pixi/bin/pixi run -e beta check-patches
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform linux-64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform linux-64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
     - name: Build recipes for linux-aarch64
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-aarch64'
       run: |
+        env -i $HOME/.pixi/bin/pixi run -e beta check-patches
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform linux-aarch64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform linux-aarch64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
     - name: Build recipes for osx-64
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'osx-64'
       run: |
+        env -i $HOME/.pixi/bin/pixi run -e beta check-patches
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform osx-64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform osx-64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
     - name: Build recipes for osx-arm64
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'osx-arm64'
       run: |
+        env -i $HOME/.pixi/bin/pixi run -e beta check-patches
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform osx-arm64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform osx-arm64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
     - name: Build recipes for win-64
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'win-64'
       run: |
+        $HOME/.pixi/bin/pixi run -e beta check-patches
         $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform win-64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing
         $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform win-64 -m ./conda_build_config.yaml -c robostack-kilted -c conda-forge --skip-existing

--- a/check_patches_clean_apply.py
+++ b/check_patches_clean_apply.py
@@ -1,48 +1,177 @@
-# Useful script when checking whether patches apply cleanly.
-# First, run `vinca` (without `-m` flag) to generate a recipe.yaml.
-# Then, run this script to generate a new pseudo list that only contains sources that have patches applied.
-# This you can then run through `boa` which will try and apply the patches.
+#!/usr/bin/env python3
+"""
+check_patches_clean_apply.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Scan *all* recipes inside the **recipes/** folder, keep only the parts
+needed to verify that every declared *patch* still applies, and then
+run **rattler-build** so the patch phase is executed – nothing else.
 
-import yaml
+Usage
+-----
+
+    # From repository root
+    python .scripts/check_patches_clean_apply.py          # prepare + run
+    python .scripts/check_patches_clean_apply.py --dry    # prepare only
+    python .scripts/check_patches_clean_apply.py --clean  # delete output
+
+The script creates (or refreshes) a sibling folder named
+*recipes_only_patch*.  Every recipe that declares *patches:* gets a
+**minimal** copy there; files referenced in *patches* are copied too.
+
+Implementation details
+----------------------
+
+* Accepts both mapping or list forms of *source*.
+* Strips out *requirements*, *test*, *outputs*… – only *package*,
+  *source* and a stub *build* section remain.
+* Automatically invokes ``rattler-build build`` if *--dry* is **not**
+  given.
+"""
+
+from __future__ import annotations
+
+import argparse
 import shutil
-import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Union
+import yaml
 
-SCRIPT_DIR = './'
 
-shutil.move(SCRIPT_DIR + '/recipe.yaml', SCRIPT_DIR + '/recipe.yaml.bak')
+ROOT_DIR = Path.cwd()
+RECIPES_DIR = ROOT_DIR / "recipes"
+PATCH_RECIPES_DIR = ROOT_DIR / "recipes_only_patch"
 
-# Load the YAML file
-with open('recipe.yaml.bak', 'r') as file:
-    data = yaml.safe_load(file)
 
-prepend_data = {
-    'package': {
-        'name': 'ros-dummy',
-        'version': '2024.01.17'
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Check that patches apply cleanly.")
+    ap.add_argument(
+        "--dry",
+        action="store_true",
+        help="Only generate recipes_only_patch/, don’t run rattler-build",
+    )
+    ap.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove recipes_only_patch/ and exit",
+    )
+    ap.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=1,
+        help="Parallel jobs to pass to rattler-build (default: 1)",
+    )
+    return ap.parse_args()
+
+
+def find_recipe_files() -> List[Path]:
+    return sorted(RECIPES_DIR.rglob("recipe.yaml"))
+
+
+def filter_sources(src: Union[Dict[str, Any], List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    if isinstance(src, dict):
+        return [src] if "patches" in src else []
+    elif isinstance(src, list):
+        return [entry for entry in src if isinstance(entry, dict) and "patches" in entry]
+    return []
+
+
+def copy_patch_files(
+    filtered_sources: List[Dict[str, Any]], orig_recipe_dir: Path, dest_recipe_dir: Path
+) -> None:
+    for entry in filtered_sources:
+        patches = entry["patches"]
+        if isinstance(patches, str):
+            patches = [patches]
+        for p in patches:
+            if p.startswith(("http://", "https://")):
+                # Remote patches – nothing to copy
+                continue
+            src_patch = (orig_recipe_dir / p).resolve()
+            dest_patch = dest_recipe_dir / p
+            dest_patch.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_patch, dest_patch)
+
+
+def write_minimal_recipe(
+    dest_recipe_file: Path, pkg: Dict[str, Any], filtered_sources: List[Dict[str, Any]]
+) -> None:
+    minimal = {
+        "package": pkg,
+        "source": filtered_sources,
+        "build": {"number": 0, "script": "echo patch-check"},
     }
-}
+    dest_recipe_file.parent.mkdir(parents=True, exist_ok=True)
+    with dest_recipe_file.open("w", encoding="utf-8") as fh:
+        yaml.dump(minimal, fh, sort_keys=False)
 
-append_data = {
-    'build': {
-        'number': 0
-    },
-    'about': {
-        'home': 'https://www.ros.org/',
-        'license': 'BSD-3-Clause',
-        'summary': 'Robot Operating System'
-    },
-    'extra': {
-        'recipe-maintainers': [
-            'ros-forge'
-        ]
-    }
-}
 
-# Filter out entries without 'patches'
-filtered_data = [entry for entry in data['source'] if 'patches' in entry]
+def prepare_patch_recipes() -> List[Path]:
+    recreated: List[Path] = []
+    for recipe_file in find_recipe_files():
+        with recipe_file.open("r", encoding="utf-8") as fh:
+            recipe = yaml.safe_load(fh) or {}
 
-final_data = {**prepend_data, 'source': filtered_data, **append_data}
+        src_section = recipe.get("source")
+        if src_section is None:
+            continue
+        filtered = filter_sources(src_section)
+        if not filtered:
+            # No patches → skip
+            continue
 
-# Write the filtered data back to a YAML file
-with open('recipe.yaml', 'w') as file:
-    yaml.dump(final_data, file, sort_keys=False)
+        pkg = recipe.get("package", {"name": recipe_file.parent.name, "version": "0"})
+        rel_dir = recipe_file.parent.relative_to(RECIPES_DIR)
+        dest_recipe_dir = PATCH_RECIPES_DIR / rel_dir
+        dest_recipe_file = dest_recipe_dir / "recipe.yaml"
+
+        copy_patch_files(filtered, recipe_file.parent, dest_recipe_dir)
+        write_minimal_recipe(dest_recipe_file, pkg, filtered)
+        recreated.append(dest_recipe_file)
+
+    return recreated
+
+
+def run_rattler_build(jobs: int) -> None:
+    cmd = [
+        "rattler-build",
+        "build",
+        "--recipe-dir",
+        str(PATCH_RECIPES_DIR)
+    ]
+    print("\n🔧  Running:", " ".join(cmd), "\n", flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not RECIPES_DIR.is_dir():
+        sys.exit("❌  recipes/ folder not found – abort.")
+
+    if args.clean:
+        shutil.rmtree(PATCH_RECIPES_DIR, ignore_errors=True)
+        print("🧹  Removed recipes_only_patch/")
+        return
+
+    if PATCH_RECIPES_DIR.exists():
+        print("♻️   Refreshing recipes_only_patch/ …")
+        shutil.rmtree(PATCH_RECIPES_DIR)
+
+    recreated = prepare_patch_recipes()
+    if not recreated:
+        sys.exit("⚠️  No recipes with patches found – nothing to test.")
+
+    print(f"✅  Prepared {len(recreated)} minimal recipe(s) in {PATCH_RECIPES_DIR}/")
+
+    if not args.dry:
+        run_rattler_build(args.jobs)
+    else:
+        print("💡  --dry given – rattler-build not executed.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/check_patches_clean_apply.py
+++ b/check_patches_clean_apply.py
@@ -56,13 +56,6 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Remove recipes_only_patch/ and exit",
     )
-    ap.add_argument(
-        "--jobs",
-        "-j",
-        type=int,
-        default=1,
-        help="Parallel jobs to pass to rattler-build (default: 1)",
-    )
     return ap.parse_args()
 
 
@@ -134,7 +127,7 @@ def prepare_patch_recipes() -> List[Path]:
     return recreated
 
 
-def run_rattler_build(jobs: int) -> None:
+def run_rattler_build() -> None:
     cmd = [
         "rattler-build",
         "build",
@@ -167,7 +160,7 @@ def main() -> None:
     print(f"✅  Prepared {len(recreated)} minimal recipe(s) in {PATCH_RECIPES_DIR}/")
 
     if not args.dry:
-        run_rattler_build(args.jobs)
+        run_rattler_build()
     else:
         print("💡  --dry given – rattler-build not executed.")
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,7 +33,8 @@ vinca = { git ="https://github.com/RoboStack/vinca.git", rev = "cbb8eba834ce3834
 
 [feature.beta.tasks]
 generate-recipes = { cmd = "vinca -m", depends-on = ["rename-file"] }
-remove-file = { cmd = "rm vinca.yaml; rm -rf recipes; mkdir recipes" }
+remove-file = { cmd = "rm vinca.yaml; rm -rf recipes_only_patch; -rf recipes; mkdir recipes" }
+check-patches = { cmd = "python check_patches_clean_apply.py", depends-on = ["generate-recipes"] }
 build_additional_recipes = { cmd = "rattler-build build --recipe-dir ./additional_recipes -m ./conda_build_config.yaml --skip-existing -c robostack-kilted -c https://repo.prefix.dev/conda-forge", depends-on = ["generate-recipes"] }
 build = { cmd = "rattler-build build --recipe-dir ./recipes -m ./conda_build_config.yaml -c robostack-kilted -c https://repo.prefix.dev/conda-forge --skip-existing", depends-on = ["build_additional_recipes", "generate-recipes"] }
 build_one_package = { cmd = "cp ./patch/$PACKAGE.*patch ./recipes/$PACKAGE/patch/; rattler-build build --recipe ./recipes/$PACKAGE/recipe.yaml -m ./conda_build_config.yaml -c robostack-kilted -c https://repo.prefix.dev/conda-forge", env = { PACKAGE = "ros-kilted-ros-workspace" } }


### PR DESCRIPTION
In this way, checking that patches apply cleanly is much faster, as you only need to run `pixi run check-patches`. Also the CI fail much earlier now, as it also runs `pixi run check-patches` before actually running the build. 

@wep21 hopefully this should help speed up your great maintenance work!

For transparency, the initial porting was done by OpenAI o3, and I then tweaked the script with some testing, see https://chatgpt.com/share/684dab79-8f4c-8006-a665-b1b558e2e29f .